### PR TITLE
Fix for use with SSR frameworks like Remix

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ const classes = ${classNames};
 const css = \`${result.css}\`;
 ${options.inject && `
 (function() {
-  if (!document.getElementById(digest)) {
+  if (typeof document !== "undefined" && !document.getElementById(digest)) {
     var ele = document.createElement('style');
     ele.id = digest;
     ele.textContent = css;


### PR DESCRIPTION
Not sure if this is something you'd want to do this way, or allow for an override of the `inject` function on config, but we were having issues using the loader with Remix because the `document` isn't available. This just adds a simple check to see if document is defined or not, and if not doesn't run the script. I've tested with recent builds of Remix, and it's working great.

We're operating on a fork right now, but would love to merge into the overall project. Let me know if you have any questions.